### PR TITLE
cloudflared: implement maxConcurrentRequests

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -249,11 +249,12 @@ type IngressIPRule struct {
 }
 
 type Configuration struct {
-	TunnelID      string `yaml:"tunnel"`
-	Ingress       []UnvalidatedIngressRule
-	WarpRouting   WarpRoutingConfig   `yaml:"warp-routing"`
-	OriginRequest OriginRequestConfig `yaml:"originRequest"`
-	sourceFile    string
+	TunnelID              string `yaml:"tunnel"`
+	Ingress               []UnvalidatedIngressRule
+	WarpRouting           WarpRoutingConfig   `yaml:"warp-routing"`
+	OriginRequest         OriginRequestConfig `yaml:"originRequest"`
+	MaxConcurrentRequests uint64              `yaml:"maxConcurrentRequests"`
+	sourceFile            string
 }
 
 type WarpRoutingConfig struct {

--- a/ingress/config.go
+++ b/ingress/config.go
@@ -98,7 +98,7 @@ func (rc *RemoteConfig) UnmarshalJSON(b []byte) error {
 		globalOriginRequestConfig = &config.OriginRequestConfig{}
 	}
 
-	ingress, err := validateIngress(rawConfig.IngressRules, originRequestFromConfig(*globalOriginRequestConfig))
+	ingress, err := validateIngress(rawConfig.IngressRules, originRequestFromConfig(*globalOriginRequestConfig), 0)
 	if err != nil {
 		return err
 	}

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -79,8 +79,9 @@ type Ingress struct {
 	// Set of ingress rules that are not added to remote config, e.g. management
 	InternalRules []Rule
 	// Rules that are provided by the user from remote or local configuration
-	Rules    []Rule              `json:"ingress"`
-	Defaults OriginRequestConfig `json:"originRequest"`
+	Rules                 []Rule              `json:"ingress"`
+	Defaults              OriginRequestConfig `json:"originRequest"`
+	MaxConcurrentRequests uint64              `json:"maxConcurrentRequests"`
 }
 
 // ParseIngress parses ingress rules, but does not send HTTP requests to the origins.

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -89,7 +89,7 @@ func ParseIngress(conf *config.Configuration) (Ingress, error) {
 	if conf == nil || len(conf.Ingress) == 0 {
 		return Ingress{}, ErrNoIngressRules
 	}
-	return validateIngress(conf.Ingress, originRequestFromConfig(conf.OriginRequest))
+	return validateIngress(conf.Ingress, originRequestFromConfig(conf.OriginRequest), conf.MaxConcurrentRequests)
 }
 
 // ParseIngressFromConfigAndCLI will parse the configuration rules from config files for ingress
@@ -243,7 +243,7 @@ func validateAccessConfiguration(cfg *config.AccessConfig) error {
 	return nil
 }
 
-func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginRequestConfig) (Ingress, error) {
+func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginRequestConfig, maxConcurrentRequests uint64) (Ingress, error) {
 	rules := make([]Rule, len(ingress))
 	for i, r := range ingress {
 		cfg := setConfig(defaults, r.OriginRequest)
@@ -356,7 +356,7 @@ func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginReq
 			Config:           cfg,
 		}
 	}
-	return Ingress{Rules: rules, Defaults: defaults}, nil
+	return Ingress{Rules: rules, Defaults: defaults, MaxConcurrentRequests: maxConcurrentRequests}, nil
 }
 
 func validateHostname(r config.UnvalidatedIngressRule, ruleIndex, totalRules int) error {

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -136,7 +136,7 @@ func (o *Orchestrator) updateIngress(ingressRules ingress.Ingress, warpRouting i
 	if err := ingressRules.StartOrigins(o.log, proxyShutdownC); err != nil {
 		return errors.Wrap(err, "failed to start origin")
 	}
-	proxy := proxy.NewOriginProxy(ingressRules, warpRouting, o.tags, o.config.WriteTimeout, o.log)
+	proxy := proxy.NewOriginProxy(ingressRules, warpRouting, o.tags, o.config.WriteTimeout, o.log, ingressRules.MaxConcurrentRequests)
 	o.proxy.Store(proxy)
 	o.config.Ingress = &ingressRules
 	o.config.WarpRouting = warpRouting

--- a/proxy/metrics.go
+++ b/proxy/metrics.go
@@ -35,6 +35,15 @@ var (
 		},
 		[]string{"status_code"},
 	)
+	earlyResponseByCode = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: connection.MetricsNamespace,
+			Subsystem: connection.TunnelSubsystem,
+			Name:      "early_response_by_code",
+			Help:      "Count of responses by HTTP status code, incremented as soon as it is known",
+		},
+		[]string{"status_code"},
+	)
 	requestErrors = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: connection.MetricsNamespace,
@@ -83,6 +92,7 @@ func init() {
 		totalRequests,
 		concurrentRequests,
 		responseByCode,
+		earlyResponseByCode,
 		requestErrors,
 		activeTCPSessions,
 		totalTCPSessions,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -217,6 +217,7 @@ func (p *Proxy) proxyHTTPRequest(
 	tracing.EndWithStatusCode(ttfbSpan, resp.StatusCode)
 	defer resp.Body.Close()
 
+	earlyResponseByCode.WithLabelValues(strconv.Itoa(resp.StatusCode)).Inc()
 	headers := make(http.Header, len(resp.Header))
 	// copy headers
 	for k, v := range resp.Header {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -162,7 +162,7 @@ func TestProxySingleOrigin(t *testing.T) {
 
 	require.NoError(t, ingressRule.StartOrigins(&log, ctx.Done()))
 
-	proxy := NewOriginProxy(ingressRule, noWarpRouting, testTags, time.Duration(0), &log)
+	proxy := NewOriginProxy(ingressRule, noWarpRouting, testTags, time.Duration(0), &log, 0)
 	t.Run("testProxyHTTP", testProxyHTTP(proxy))
 	t.Run("testProxyWebsocket", testProxyWebsocket(proxy))
 	t.Run("testProxySSE", testProxySSE(proxy))
@@ -366,7 +366,7 @@ func runIngressTestScenarios(t *testing.T, unvalidatedIngress []config.Unvalidat
 	ctx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, ingress.StartOrigins(&log, ctx.Done()))
 
-	proxy := NewOriginProxy(ingress, noWarpRouting, testTags, time.Duration(0), &log)
+	proxy := NewOriginProxy(ingress, noWarpRouting, testTags, time.Duration(0), &log, 0)
 
 	for _, test := range tests {
 		responseWriter := newMockHTTPRespWriter()
@@ -414,7 +414,7 @@ func TestProxyError(t *testing.T) {
 
 	log := zerolog.Nop()
 
-	proxy := NewOriginProxy(ing, noWarpRouting, testTags, time.Duration(0), &log)
+	proxy := NewOriginProxy(ing, noWarpRouting, testTags, time.Duration(0), &log, 0)
 
 	responseWriter := newMockHTTPRespWriter()
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
@@ -675,7 +675,7 @@ func TestConnections(t *testing.T) {
 
 			ingressRule := createSingleIngressConfig(t, test.args.ingressServiceScheme+ln.Addr().String())
 			ingressRule.StartOrigins(logger, ctx.Done())
-			proxy := NewOriginProxy(ingressRule, testWarpRouting, testTags, time.Duration(0), logger)
+			proxy := NewOriginProxy(ingressRule, testWarpRouting, testTags, time.Duration(0), logger, 0)
 			proxy.warpRouting = test.args.warpRoutingService
 
 			dest := ln.Addr().String()


### PR DESCRIPTION
This adds a config setting to cap the max number of concurrent (outstanding) requests in cloudflared. When the number of concurrent requests exceeds the limit, the agent will fail new requests with HTTP status 429 (too many requests).

This protects the agent (and the device it runs on) from uncontrolled memory and resource growth (ESC-1748 and EV-2376). See https://www.notion.so/spotai/Ingress-tunnel-request-storm-investigation-59f9f0d67edc40bf8bbe7c8582c3a515 for a detailed description of the problem. This change also adds the `cloudflared_tunnel_early_response_by_code` metric that the investigation used to find the root of the problem.

**Testing**:
I tested the new setting by running an experiment in which it is set to 55. I placed the system under the same kind of load (hybrid AI) that caused ESC-1748. I observed requests being rejected with status 429, as expected. Given that upload bandwidth was saturated, HLS became laggy but recovered once in a while. WebRTC did better. The agent's physical memory consumption grew modestly from 60 to 80 MB. Everything came back down after the load was turned off.