### PR TITLE
add includeWebsocketsInMaxConcurrentRequests

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -249,12 +249,13 @@ type IngressIPRule struct {
 }
 
 type Configuration struct {
-	TunnelID              string `yaml:"tunnel"`
-	Ingress               []UnvalidatedIngressRule
-	WarpRouting           WarpRoutingConfig   `yaml:"warp-routing"`
-	OriginRequest         OriginRequestConfig `yaml:"originRequest"`
-	MaxConcurrentRequests uint64              `yaml:"maxConcurrentRequests"`
-	sourceFile            string
+	TunnelID                                 string `yaml:"tunnel"`
+	Ingress                                  []UnvalidatedIngressRule
+	WarpRouting                              WarpRoutingConfig   `yaml:"warp-routing"`
+	OriginRequest                            OriginRequestConfig `yaml:"originRequest"`
+	MaxConcurrentRequests                    uint64              `yaml:"maxConcurrentRequests"`
+	IncludeWebsocketsInMaxConcurrentRequests bool                `yaml:"includeWebsocketsInMaxConcurrentRequests"`
+	sourceFile                               string
 }
 
 type WarpRoutingConfig struct {

--- a/ingress/config.go
+++ b/ingress/config.go
@@ -98,7 +98,7 @@ func (rc *RemoteConfig) UnmarshalJSON(b []byte) error {
 		globalOriginRequestConfig = &config.OriginRequestConfig{}
 	}
 
-	ingress, err := validateIngress(rawConfig.IngressRules, originRequestFromConfig(*globalOriginRequestConfig), 0)
+	ingress, err := validateIngress(rawConfig.IngressRules, originRequestFromConfig(*globalOriginRequestConfig), 0, false)
 	if err != nil {
 		return err
 	}

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -91,7 +91,7 @@ func ParseIngress(conf *config.Configuration) (Ingress, error) {
 		return Ingress{}, ErrNoIngressRules
 	}
 	return validateIngress(conf.Ingress, originRequestFromConfig(conf.OriginRequest),
-		conf.MaxConcurrentRequests)
+		conf.MaxConcurrentRequests, conf.IncludeWebsocketsInMaxConcurrentRequests)
 }
 
 // ParseIngressFromConfigAndCLI will parse the configuration rules from config files for ingress
@@ -245,7 +245,8 @@ func validateAccessConfiguration(cfg *config.AccessConfig) error {
 	return nil
 }
 
-func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginRequestConfig, maxConcurrentRequests uint64) (Ingress, error) {
+func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginRequestConfig,
+	maxConcurrentRequests uint64, includeWebsocketsInMaxConcurrentRequests bool) (Ingress, error) {
 	rules := make([]Rule, len(ingress))
 	for i, r := range ingress {
 		cfg := setConfig(defaults, r.OriginRequest)
@@ -358,7 +359,7 @@ func validateIngress(ingress []config.UnvalidatedIngressRule, defaults OriginReq
 			Config:           cfg,
 		}
 	}
-	return Ingress{Rules: rules, Defaults: defaults, MaxConcurrentRequests: maxConcurrentRequests}, nil
+	return Ingress{Rules: rules, Defaults: defaults, MaxConcurrentRequests: maxConcurrentRequests, IncludeWebsocketsInMaxConcurrentRequests: includeWebsocketsInMaxConcurrentRequests}, nil
 }
 
 func validateHostname(r config.UnvalidatedIngressRule, ruleIndex, totalRules int) error {

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -79,9 +79,10 @@ type Ingress struct {
 	// Set of ingress rules that are not added to remote config, e.g. management
 	InternalRules []Rule
 	// Rules that are provided by the user from remote or local configuration
-	Rules                 []Rule              `json:"ingress"`
-	Defaults              OriginRequestConfig `json:"originRequest"`
-	MaxConcurrentRequests uint64              `json:"maxConcurrentRequests"`
+	Rules                                    []Rule              `json:"ingress"`
+	Defaults                                 OriginRequestConfig `json:"originRequest"`
+	MaxConcurrentRequests                    uint64              `json:"maxConcurrentRequests"`
+	IncludeWebsocketsInMaxConcurrentRequests bool                `json:"includeWebsocketsInMaxConcurrentRequests"`
 }
 
 // ParseIngress parses ingress rules, but does not send HTTP requests to the origins.
@@ -89,7 +90,8 @@ func ParseIngress(conf *config.Configuration) (Ingress, error) {
 	if conf == nil || len(conf.Ingress) == 0 {
 		return Ingress{}, ErrNoIngressRules
 	}
-	return validateIngress(conf.Ingress, originRequestFromConfig(conf.OriginRequest), conf.MaxConcurrentRequests)
+	return validateIngress(conf.Ingress, originRequestFromConfig(conf.OriginRequest),
+		conf.MaxConcurrentRequests)
 }
 
 // ParseIngressFromConfigAndCLI will parse the configuration rules from config files for ingress

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -136,7 +136,8 @@ func (o *Orchestrator) updateIngress(ingressRules ingress.Ingress, warpRouting i
 	if err := ingressRules.StartOrigins(o.log, proxyShutdownC); err != nil {
 		return errors.Wrap(err, "failed to start origin")
 	}
-	proxy := proxy.NewOriginProxy(ingressRules, warpRouting, o.tags, o.config.WriteTimeout, o.log, ingressRules.MaxConcurrentRequests)
+	proxy := proxy.NewOriginProxy(ingressRules, warpRouting, o.tags, o.config.WriteTimeout, o.log,
+		ingressRules.MaxConcurrentRequests, ingressRules.IncludeWebsocketsInMaxConcurrentRequests)
 	o.proxy.Store(proxy)
 	o.config.Ingress = &ingressRules
 	o.config.WarpRouting = warpRouting

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -30,12 +30,13 @@ const (
 
 // Proxy represents a means to Proxy between cloudflared and the origin services.
 type Proxy struct {
-	ingressRules          ingress.Ingress
-	warpRouting           *ingress.WarpRoutingService
-	management            *ingress.ManagementService
-	tags                  []tunnelpogs.Tag
-	log                   *zerolog.Logger
-	maxConcurrentRequests uint64
+	ingressRules                             ingress.Ingress
+	warpRouting                              *ingress.WarpRoutingService
+	management                               *ingress.ManagementService
+	tags                                     []tunnelpogs.Tag
+	log                                      *zerolog.Logger
+	maxConcurrentRequests                    uint64
+	includeWebsocketsInMaxConcurrentRequests bool
 }
 
 // NewOriginProxy returns a new instance of the Proxy struct.
@@ -46,12 +47,14 @@ func NewOriginProxy(
 	writeTimeout time.Duration,
 	log *zerolog.Logger,
 	maxConcurrentRequests uint64,
+	includeWebsocketsInMaxConcurrentRequests bool,
 ) *Proxy {
 	proxy := &Proxy{
-		ingressRules:          ingressRules,
-		tags:                  tags,
-		log:                   log,
-		maxConcurrentRequests: maxConcurrentRequests,
+		ingressRules:                             ingressRules,
+		tags:                                     tags,
+		log:                                      log,
+		maxConcurrentRequests:                    maxConcurrentRequests,
+		includeWebsocketsInMaxConcurrentRequests: includeWebsocketsInMaxConcurrentRequests,
 	}
 
 	proxy.warpRouting = ingress.NewWarpRoutingService(warpRouting, writeTimeout)
@@ -83,6 +86,10 @@ func (p *Proxy) ProxyHTTP(
 ) error {
 	incrementRequests()
 	defer decrementConcurrentRequests()
+	if isWebsocket {
+		incrementConcurrentWebsocketRequests()
+		defer decrementConcurrentWebsocketRequests()
+	}
 
 	req := tr.Request
 	p.appendTagHeaders(req)
@@ -103,15 +110,25 @@ func (p *Proxy) ProxyHTTP(
 	}
 
 	// Fail request if over concurrency limit
-	if p.maxConcurrentRequests > 0 && readConcurrentRequests() > p.maxConcurrentRequests {
-		resp := http.Response{StatusCode: http.StatusTooManyRequests}
-		resp.Status = http.StatusText(resp.StatusCode)
-		err := w.WriteRespHeaders(resp.StatusCode, nil)
-		if err != nil {
-			return errors.Wrap(err, "Error writing response header")
+	if p.maxConcurrentRequests > 0 {
+		totalCount := readConcurrentRequests()
+		if !p.includeWebsocketsInMaxConcurrentRequests {
+			// Exclude websocket requests from the count
+			websocketCount := readConcurrentWebsocketRequests()
+			if totalCount > websocketCount {
+				totalCount = totalCount - websocketCount
+			}
 		}
-		logOriginHTTPResponse(&logger, &resp)
-		return nil
+		if totalCount > p.maxConcurrentRequests {
+			resp := http.Response{StatusCode: http.StatusTooManyRequests}
+			resp.Status = http.StatusText(resp.StatusCode)
+			err := w.WriteRespHeaders(resp.StatusCode, nil)
+			if err != nil {
+				return errors.Wrap(err, "Error writing response header")
+			}
+			logOriginHTTPResponse(&logger, &resp)
+			return nil
+		}
 	}
 
 	switch originProxy := rule.Service.(type) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -115,7 +115,7 @@ func (p *Proxy) ProxyHTTP(
 		if !p.includeWebsocketsInMaxConcurrentRequests {
 			// Exclude websocket requests from the count
 			websocketCount := readConcurrentWebsocketRequests()
-			if totalCount > websocketCount {
+			if totalCount >= websocketCount {
 				totalCount = totalCount - websocketCount
 			}
 		}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -162,7 +162,7 @@ func TestProxySingleOrigin(t *testing.T) {
 
 	require.NoError(t, ingressRule.StartOrigins(&log, ctx.Done()))
 
-	proxy := NewOriginProxy(ingressRule, noWarpRouting, testTags, time.Duration(0), &log, 0)
+	proxy := NewOriginProxy(ingressRule, noWarpRouting, testTags, time.Duration(0), &log, 0, false)
 	t.Run("testProxyHTTP", testProxyHTTP(proxy))
 	t.Run("testProxyWebsocket", testProxyWebsocket(proxy))
 	t.Run("testProxySSE", testProxySSE(proxy))
@@ -366,7 +366,7 @@ func runIngressTestScenarios(t *testing.T, unvalidatedIngress []config.Unvalidat
 	ctx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, ingress.StartOrigins(&log, ctx.Done()))
 
-	proxy := NewOriginProxy(ingress, noWarpRouting, testTags, time.Duration(0), &log, 0)
+	proxy := NewOriginProxy(ingress, noWarpRouting, testTags, time.Duration(0), &log, 0, false)
 
 	for _, test := range tests {
 		responseWriter := newMockHTTPRespWriter()
@@ -414,7 +414,7 @@ func TestProxyError(t *testing.T) {
 
 	log := zerolog.Nop()
 
-	proxy := NewOriginProxy(ing, noWarpRouting, testTags, time.Duration(0), &log, 0)
+	proxy := NewOriginProxy(ing, noWarpRouting, testTags, time.Duration(0), &log, 0, false)
 
 	responseWriter := newMockHTTPRespWriter()
 	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1", nil)
@@ -675,7 +675,7 @@ func TestConnections(t *testing.T) {
 
 			ingressRule := createSingleIngressConfig(t, test.args.ingressServiceScheme+ln.Addr().String())
 			ingressRule.StartOrigins(logger, ctx.Done())
-			proxy := NewOriginProxy(ingressRule, testWarpRouting, testTags, time.Duration(0), logger, 0)
+			proxy := NewOriginProxy(ingressRule, testWarpRouting, testTags, time.Duration(0), logger, 0, false)
 			proxy.warpRouting = test.args.warpRoutingService
 
 			dest := ln.Addr().String()


### PR DESCRIPTION
Websocket requests are long-running HTTP requests that essentially never complete. They start as HTTP with the Upgrade option, then turn into a bidirectional byte stream. This change introduces a config flag to include or exclude outstanding websocket requests from the maxConcurrentRequests calculation, if that limit is enabled (> 0). Specifically, if `includeWebsocketsInMaxConcurrentRequests` is true, then outstanding websocket requests are included in the total request count to be compared against the max. If false (the default), the number of outstanding websocket requests is subtracted from the total request count, effectively increasing the available limit by ignoring websockets.

Testing:

- On appliance `sn7d-nhwe3p`, I set `maxConcurrentRequests` to 14, and activated two walls of 7 WebRTC streams, resulting in 14 long-lived WebRTC connections to livekitserver. So the total outstanding request count is at the max.
- With `includeWebsocketsInMaxConcurrentRequests` set to true, when activating an HLS live stream in a separate tab, the stream fails to load, with HTTP requests returning the expected 429 responses.
- With `includeWebsocketsInMaxConcurrentRequests` set to false (or unspecified), the HLS live stream loads successfully.